### PR TITLE
Set git clone path to ...java-ce-root instead of ...android-ce-root

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,11 +27,11 @@ See: [Todo](https://github.com/couchbaselabs/mobile-training-todo/tree/feature/2
 
 This project is a git repository with submodules.  To check it out, clone this root repository:
 
-`git clone https://github.com/couchbase/couchbase-lite-android-ce-root --recurse-submodules`
+`git clone https://github.com/couchbase/couchbase-lite-java-ce-root --recurse-submodules`
 
 or
 
-`git clone https://github.com/couchbase/couchbase-lite-android-ce-root`
+`git clone https://github.com/couchbase/couchbase-lite-java-ce-root`
 `git submodule update --init --recursive`
 
 ## Organization


### PR DESCRIPTION
Running the clone command found in the readme failed.
```
git clone https://github.com/couchbase/couchbase-lite-android-ce-root --recurse-submodules
Cloning into 'couchbase-lite-android-ce-root'...
remote: Repository not found.
fatal: repository 'https://github.com/couchbase/couchbase-lite-android-ce-root/' not found
```
Setting the path to ...java-ce-root instead of ...android-ce-root clones the repo successfully.